### PR TITLE
Make actionSpace and observationSpace public in design

### DIFF
--- a/design.md
+++ b/design.md
@@ -162,8 +162,8 @@ gymnasium/core.ts
 ```ts
 abstract class Env {
     protected renderMode: str;
-    protected actionSpace: ActSpace;
-    protected observationSpace: ObsSpace;
+    public actionSpace: ActSpace;
+    public observationSpace: ObsSpace;
 
     abstract reset(): [Box, object];
     abstract async step(action: number): [Box, number, boolean, boolean, object]; // Action is number for now


### PR DESCRIPTION
These objects have to be public as they are to be accessed outside of the class, for example when making a sample or when constructing a model based on the observation and action space of the environment.