### PR TITLE
Make n and start public in Discrete

### DIFF
--- a/design.md
+++ b/design.md
@@ -111,8 +111,8 @@ gymnasium/spaces/discrete
 .ts
 ```ts
 class Discrete extends Space {
-    private n: number;
-    private start: number;
+    public n: number;
+    public start: number;
     
     constructor(n: number, start: number = 0) {
         super(shape: [], dtype: "int32")


### PR DESCRIPTION
Make `n` and `start` public as they are necessary to know outside the class (for the same reason as Space).