### PR TITLE
Style: Use export declarations instead of export list for spaces

### DIFF
--- a/src/spaces/box.ts
+++ b/src/spaces/box.ts
@@ -1,7 +1,7 @@
 import * as tf from '@tensorflow/tfjs';
 import { Space } from './space';
 
-class Box extends Space {
+export class Box extends Space {
     public low: number;
     public high: number;
     
@@ -15,5 +15,3 @@ class Box extends Space {
         return tf.randomUniform(this.shape, this.low, this.high, this.dtype);
     }
 }
-
-export { Box }

--- a/src/spaces/discrete.ts
+++ b/src/spaces/discrete.ts
@@ -1,7 +1,7 @@
 import * as tf from '@tensorflow/tfjs';
 import { Space } from './space';
 
-class Discrete extends Space {
+export class Discrete extends Space {
     public n: number;
     public start: number;
     
@@ -19,5 +19,3 @@ class Discrete extends Space {
         return randomNumber;
     }
 }
-
-export { Discrete }

--- a/src/spaces/space.ts
+++ b/src/spaces/space.ts
@@ -1,6 +1,6 @@
 import * as tf from '@tensorflow/tfjs';
 
-abstract class Space {
+export abstract class Space {
     public shape: number[];
     public dtype: tf.DataType;
     
@@ -11,5 +11,3 @@ abstract class Space {
     
     abstract sample(): tf.Tensor | number;
 }
-
-export { Space }


### PR DESCRIPTION
We use export declarations instead of export lists as it's more preferable.