### PR TITLE
Envs: Use window instead of process to check isNode

### DIFF
--- a/src/envs/classic_control/cartpole.ts
+++ b/src/envs/classic_control/cartpole.ts
@@ -72,7 +72,7 @@ export class CartPoleEnv extends Env<tf.Tensor, number> {
     this.window = undefined;
     this.createWindowPromise = null;
 
-    const isNode = typeof process === 'object';
+    const isNode = typeof window === 'undefined';
 
     if (!isNode && renderMode !== null && canvas === null) {
       throw Error('Canvas must be provied in rendering mode in web!');

--- a/src/envs/classic_control/pendulum.ts
+++ b/src/envs/classic_control/pendulum.ts
@@ -66,7 +66,7 @@ export class PendulumEnv extends Env<tf.Tensor, tf.Tensor> {
     this.canvas = canvas;
     this.createWindowPromise = null;
 
-    const isNode = typeof process === 'object';
+    const isNode = typeof window === 'undefined';
 
     if (!isNode && renderMode !== null && canvas === null) {
       throw Error('Canvas must be provied in rendering mode in web!');


### PR DESCRIPTION
The code acts up if we check whether the code is running on Node JS using `process` while using 'esh.sh', so we use `window`.